### PR TITLE
29 add score and highscore to endmenu

### DIFF
--- a/src/end-menu.ts
+++ b/src/end-menu.ts
@@ -3,10 +3,11 @@ class EndMenu {
   //private score: number;
   private btnPlayAgain: Button;
   private btnMenu: Button;
+  private score: number;
 
-  constructor() {
+  constructor(score: number) {
     const centerX = width * 0.5;
-    //this.score = 0;
+    this.score = score;
     this.btnPlayAgain = new Button("PLAY AGAIN", new p5.Vector(centerX, 290), new p5.Vector(220, 60));
     this.btnMenu = new Button("MENU", new p5.Vector(centerX, 350), new p5.Vector(140, 40));
   }
@@ -28,7 +29,7 @@ class EndMenu {
     textSize(20);
     textAlign(CENTER, CENTER);
     textFont(Fonts.TitanOne);
-    text("Your score:", 278, 190);
+    text("Your score:" + " " + this.score, 278, 190);
     pop(); 
     push();
     fill("#FFFFFF");

--- a/src/end-menu.ts
+++ b/src/end-menu.ts
@@ -36,7 +36,7 @@ class EndMenu {
     textSize(20);
     textAlign(CENTER, CENTER);
     textFont(Fonts.TitanOne);
-    text("Highscore:", 278, 220);
+    text("Highscore:" + " " + game.getHighscore(), 278, 220);
     pop();
     push();
     fill("#000000");

--- a/src/end-menu.ts
+++ b/src/end-menu.ts
@@ -53,4 +53,9 @@ class EndMenu {
     text("Game Over!", 275, 100);
     pop();
   }
+
+  public setScore(score: number) {
+    this.score = score;
+}
+
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -10,11 +10,19 @@ class Game {
     this.gameBoard = new GameBoard();
     this.startMenu = new StartMenu();
     this.howToPlay = new HowToPlay();
-    this.endMenu = new EndMenu();
-    this.activeScene = "howtoplay";
+    this.endMenu = new EndMenu(this.gameBoard.getScore());
+    this.activeScene = "end";
   }
   
   public update() {
+    // PLATSHÅLLARE
+    if (keyIsPressed && key === "1"){
+      this.activeScene = "play"
+    }
+    if (keyIsPressed && key === "2"){
+      this.activeScene = "end"
+    }
+    //
     if (this.activeScene === "play") {
       this.gameBoard.update();
     } else if (this.activeScene === "start") {

--- a/src/game.ts
+++ b/src/game.ts
@@ -4,7 +4,7 @@ class Game {
   private howToPlay: HowToPlay;
   private endMenu: EndMenu;
   private activeScene: "start" | "howtoplay" | "play" | "end";
-  // private highscores: number[];
+  private _highscore: number;
 
   constructor() {
     this.gameBoard = new GameBoard();
@@ -12,9 +12,17 @@ class Game {
     this.howToPlay = new HowToPlay();
     this.endMenu = new EndMenu(this.gameBoard.getScore());
     this.activeScene = "end";
+    this._highscore = Number(localStorage.getItem("highscore")) || 0;
   }
   
+  public get highscore(): number {
+    return this._highscore;
+  }
   public update() {
+    if (this.gameBoard.getScore() > this.highscore) {
+      this._highscore = this.gameBoard.getScore();
+      localStorage.setItem("highscore", this.highscore.toString());
+    }
     // PLATSHÅLLARE
     if (keyIsPressed && key === "1"){
       this.activeScene = "play"
@@ -51,7 +59,7 @@ class Game {
     this.endMenu.setScore(this.gameBoard.getScore());
   }
 
-  public startGame() {
-
-  }
+  public getHighscore(): number {
+    return this.highscore;
+}
 }

--- a/src/game.ts
+++ b/src/game.ts
@@ -36,6 +36,7 @@ class Game {
   public draw() {
     if (this.activeScene === "play") {
       this.gameBoard.draw();
+      this.updateScore();
     } else if (this.activeScene === "start") {
       this.startMenu.draw()
     } else if (this.activeScene === "howtoplay") {
@@ -46,6 +47,9 @@ class Game {
     }
   }
 
+  public updateScore() {
+    this.endMenu.setScore(this.gameBoard.getScore());
+  }
 
   public startGame() {
 

--- a/src/gameboard.ts
+++ b/src/gameboard.ts
@@ -182,9 +182,11 @@ class GameBoard {
   }
 
   // Function to track the score of the current game and display it in the top-left corner
-  private getScore() {
-    fill(0);
+  public getScore() {
+    fill("#FFFFFF");
+    textFont(Fonts.TitanOne);
     textSize(21);
     text("Score: " + this.score, 10, 30);
+    return this.score;
   }
 }


### PR DESCRIPTION
It is now possible to show score for current "run" in the "end"-scene and a highscore in the "end"-scene that is saved in localstorage.

Would require additional work if we wish to store more than one highscore.

Temporary adjustment for switching scenes between "play" & "end" (using 1 & 2) to be able test if the scores get tracked and displayed properly between scenes.